### PR TITLE
Update city lat lon retrieval

### DIFF
--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -26,6 +26,8 @@ class City extends Model
         'country_code',
         'lat',
         'lon',
+        'timezone_offset',
+        'population',
     ];
 
     protected $filterable = [
@@ -35,6 +37,8 @@ class City extends Model
         'country_code',
         'lat',
         'lon',
+        'timezone_offset',
+        'population',
     ];
 
     protected $orderable = [
@@ -44,6 +48,8 @@ class City extends Model
         'country_code',
         'lat',
         'lon',
+        'timezone_offset',
+        'population',
     ];
 
     protected $casts = [

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -24,7 +24,8 @@ class City extends Model
         'state',
         'country',
         'country_code',
-        'coord',
+        'lat',
+        'lon',
     ];
 
     protected $filterable = [
@@ -32,6 +33,8 @@ class City extends Model
         'state',
         'country',
         'country_code',
+        'lat',
+        'lon',
     ];
 
     protected $orderable = [
@@ -39,10 +42,13 @@ class City extends Model
         'state',
         'country',
         'country_code',
+        'lat',
+        'lon',
     ];
 
     protected $casts = [
-        'coord' => 'array',
+        'lat' => 'decimal:10',
+        'lon' => 'decimal:11',
     ];
 
     public function weatherReports(): HasMany

--- a/app/Support/OpenWeatherClient.php
+++ b/app/Support/OpenWeatherClient.php
@@ -16,15 +16,15 @@ class OpenWeatherClient
      */
     private static function getData(
         string $service = 'weather',
-        string $city,
+        float $lat = null,
+        float $lon = null,
         array $params = ['units' => 'metric']
     ): ResponseInterface {
 
         $baseUrl = config('services.open_weather.api') . '/' . $service . '?appid=' . config('services.open_weather.key');
 
-        // check if the city is empty
-        if (empty($city)) {
-            throw new \InvalidArgumentException('Location is required');
+        if (empty($lat) || empty($lon)) {
+            throw new \InvalidArgumentException('Invalid location');
         }
         try {
 
@@ -32,7 +32,7 @@ class OpenWeatherClient
                 $baseUrl .= '&' . $key . '=' . $value;
             }
 
-            $baseUrl .= '&q=' . $city;
+            $baseUrl .= '&lat=' . $lat . '&lon=' . $lon;
             $client = new Client();
             $response = $client->get($baseUrl);
 
@@ -49,10 +49,20 @@ class OpenWeatherClient
      * @return ResponseInterface
      */
     public static function getWeatherData(
-        string $city,
+        float $lat = null,
+        float $lon = null,
         array $params = ['units' => 'metric']
     ): ResponseInterface {
-        return self::getData(service: 'weather', city: $city, params: $params);
+        if (empty($lat) || empty($lon)) {
+            throw new \InvalidArgumentException('Invalid location');
+        }
+
+        return self::getData(
+            service: 'weather',
+            lat: $lat,
+            lon: $lon,
+            params: $params
+        );
     }
 
     /**
@@ -61,9 +71,18 @@ class OpenWeatherClient
      * @return ResponseInterface
      */
     public static function getForecastData(
-        string $city,
+        float $lat = null,
+        float $lon = null,
         array $params = ['units' => 'metric']
     ): ResponseInterface {
-        return self::getData(service: 'forecast', city: $city, params: $params);
+        if (empty($lat) || empty($lon)) {
+            throw new \InvalidArgumentException('Invalid location');
+        }
+        return self::getData(
+            service: 'forecast',
+            lat: $lat,
+            lon: $lon,
+            params: $params
+        );
     }
 }

--- a/database/migrations/2025_02_16_183823_split_lat_and_lon_from_coord_column_from_cities_table.php
+++ b/database/migrations/2025_02_16_183823_split_lat_and_lon_from_coord_column_from_cities_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\City;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cities', function (Blueprint $table) {
+            $table->decimal('lat', 10, 8)->nullable()->after('coord');
+            $table->decimal('lon', 11, 8)->nullable()->after('lat');
+        });
+
+        City::all()->each(function ($city) {
+            $city->update([
+                'lon' => $city->coord['lon'],
+                'lat' => $city->coord['lat'],
+            ]);
+        });
+
+        Schema::table('cities', function (Blueprint $table) {
+            $table->decimal('lat', 10, 8)->nullable(false)->change();
+            $table->decimal('lon', 11, 8)->nullable(false)->change();
+        });
+
+        Schema::table('cities', function (Blueprint $table) {
+            $table->dropUnique('cities_name_state_country_code_unique');
+            $table->unique(['name', 'state', 'country_code', 'lat', 'lon'], 'cities_name_state_country_code_lat_lon_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cities', function (Blueprint $table) {
+            $table->dropColumn('lat');
+            $table->dropColumn('lon');
+
+            $table->dropUnique('cities_name_state_country_code_lat_lon_unique');
+        });
+    }
+};

--- a/database/migrations/2025_02_16_191234_drop_column_coord_from_cities_table.php
+++ b/database/migrations/2025_02_16_191234_drop_column_coord_from_cities_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\City;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cities', function (Blueprint $table) {
+            $table->dropColumn('coord');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cities', function (Blueprint $table) {
+            $table->json('coord')->nullable();
+        });
+
+        City::all()->each(function ($city) {
+            $city->update([
+                'coord' => [
+                    'lon' => $city->lon,
+                    'lat' => $city->lat,
+                ],
+            ]);
+        });
+    }
+};

--- a/resources/js/Components/SearchPanel.tsx
+++ b/resources/js/Components/SearchPanel.tsx
@@ -31,7 +31,7 @@ export default function SearchPanel(_props: any) {
         (city: string) => {
             setCity((_: string) => city);
         },
-        850 // debounce time 850ms - natural typing speed
+        700 // debounce time 700 - 850ms - natural typing speed
     );
 
     const observer = new IntersectionObserver((entries) => {

--- a/resources/js/Components/SearchPanel.tsx
+++ b/resources/js/Components/SearchPanel.tsx
@@ -27,7 +27,7 @@ export default function SearchPanel(_props: any) {
     const [typingCity, setTypingCity] = useState<string>('');
     const [inFocus, setInFocus] = useState<boolean>(false);
 
-    const fetchCityWeatherData = useDebouncedCallback(
+    const fetchCityData = useDebouncedCallback(
         (city: string) => {
             setCity((_: string) => city);
         },
@@ -68,7 +68,7 @@ export default function SearchPanel(_props: any) {
                             onChange={(e) => {
                                 e.preventDefault();
                                 setTypingCity(e.target.value);
-                                fetchCityWeatherData(e.target.value);
+                                fetchCityData(e.target.value);
                             }}
                             onFocus={() => setInFocus(true)}
                             onBlur={() => setInFocus(false)}

--- a/resources/js/Components/SearchPanel.tsx
+++ b/resources/js/Components/SearchPanel.tsx
@@ -95,7 +95,7 @@ export default function SearchPanel(_props: any) {
                                             }
                                             onClick={() => {
                                                 setTypingCity(city.name);
-                                                fetchWeatherData(city.name);
+                                                fetchWeatherData({ city: city.name, lat: city.lat, lon: city.lon });
                                             }}
                                         >
                                             <div className="">

--- a/resources/js/Context/CityProvider.tsx
+++ b/resources/js/Context/CityProvider.tsx
@@ -45,7 +45,6 @@ export function CityProvider({ children }: PropsWithChildren) {
         isLoading,
         data,
         loadMoreCities,
-        fetchData,
         pendingReset,
         reset,
     } = useGeography(cityUrl);

--- a/resources/js/Context/CurrentWeatherProvider.tsx
+++ b/resources/js/Context/CurrentWeatherProvider.tsx
@@ -19,8 +19,8 @@ export function useCurrentWeather() {
 }
 
 export default function CurrentWeatherProvider({ children }: PropsWithChildren) {
-    const { cityWeather } = useWeatherContext();
-    const { loading, data, fetcher } = useWeatherData(cityWeather);
+    const { location } = useWeatherContext();
+    const { loading, data, fetcher } = useWeatherData(location);
 
     const localTime = useMemo(() => {
         if (loading) {

--- a/resources/js/Context/ForecastDataProvider.tsx
+++ b/resources/js/Context/ForecastDataProvider.tsx
@@ -21,8 +21,8 @@ export function useForecastDataContext() {
 
 
 export default function ForecastDataProvider({ children }: PropsWithChildren) {
-    const { cityWeather } = useWeatherContext();
-    const { loading, data } = useForecastData(cityWeather);
+    const { location } = useWeatherContext();
+    const { loading, data } = useForecastData(location);
 
     /**
      *

--- a/resources/js/Context/WeatherDataProvider.tsx
+++ b/resources/js/Context/WeatherDataProvider.tsx
@@ -3,10 +3,12 @@ import {
     createContext,
     useContext,
     useReducer,
+    useMemo,
     type PropsWithChildren,
 } from 'react';
 
 export const WeatherContext = createContext<any>({
+    cityWeather: '',
     location: {
         city: null,
         lat: null,
@@ -78,10 +80,18 @@ export default function WeatherProvider({ children }: PropsWithChildren) {
         dispatchLocationResolver({ type: 'SET_LOCATION', lat, lon });
     }
 
+    const cityWeather = useMemo(() => {
+        if (location.city) {
+            return location.city;
+        }
+        return '';
+    }, [location.city]);
+
     return (
         <WeatherContext.Provider
             value={{
                 location,
+                cityWeather,
                 fetchWeatherData,
                 isFogEffectForcedOn,
                 isSunFlareEffectForcedOn,

--- a/resources/js/Context/WeatherDataProvider.tsx
+++ b/resources/js/Context/WeatherDataProvider.tsx
@@ -2,11 +2,17 @@ import {
     useState,
     createContext,
     useContext,
+    useReducer,
     type PropsWithChildren,
 } from 'react';
 
 export const WeatherContext = createContext<any>({
-    fetchWeatherData: (city: string) => { },
+    location: {
+        city: null,
+        lat: null,
+        lon: null,
+    },
+    fetchWeatherData: ({ city, lat, lon }: { city: string; lat: number; lon: number }) => { },
     isFogEffectForcedOn: false,
     isSunFlareEffectForcedOn: false,
     isRainEffectForcedOn: false,
@@ -21,21 +27,61 @@ export function useWeatherContext() {
     return context;
 };
 
+const locationResolver = (state: any, action: any) => {
+    switch (action.type) {
+        case 'SET_LOCATION':
+            return {
+                ...state,
+                city: action.city,
+                lat: action.lat,
+                lon: action.lon,
+            };
+        case 'SET_LAT':
+            return {
+                ...state,
+                lat: action.lat,
+            };
+
+        case 'SET_LON':
+            return {
+                ...state,
+                lon: action.lon,
+            };
+        case 'SET_CITY':
+            return {
+                ...state,
+                city: action.city,
+            };
+        case 'RESET_LOCATION':
+            return {
+                city: null,
+                lat: null,
+                lon: null,
+            };
+        default:
+            return state;
+    }
+}
+
 export default function WeatherProvider({ children }: PropsWithChildren) {
-    const [cityWeather, setCityWeather] = useState<string>('');
+    const [location, dispatchLocationResolver] = useReducer(locationResolver, {
+        city: null,
+        lat: null,
+        lon: null,
+    });
 
     const [isFogEffectForcedOn, setIsFogEffectForcedOn] = useState<boolean>(false);
     const [isSunFlareEffectForcedOn, setIsSunFlareEffectForcedOn] = useState<boolean>(false);
     const [isRainEffectForcedOn, setIsRainEffectForcedOn] = useState<boolean>(false);
 
-    const fetchWeatherData = (city: string) => {
-        setCityWeather((_: string) => city);
+    const fetchWeatherData = ({ city, lat, lon }: { city: string; lat: number; lon: number }) => {
+        dispatchLocationResolver({ type: 'SET_LOCATION', lat, lon });
     }
 
     return (
         <WeatherContext.Provider
             value={{
-                cityWeather,
+                location,
                 fetchWeatherData,
                 isFogEffectForcedOn,
                 isSunFlareEffectForcedOn,

--- a/resources/js/Hooks/useWeather.tsx
+++ b/resources/js/Hooks/useWeather.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
-export function useForecastData(city: string) {
+export function useForecastData(location: { city: string; lat: number; lon: number }) {
+    const { city, lat, lon } = location;
     const [loading, setLoading] = useState<boolean>(false);
     const [data, setData] = useState<any>(null);
     const [error, setError] = useState<any>(null);
@@ -10,13 +11,13 @@ export function useForecastData(city: string) {
             return;
         }
 
-        if (city.length === 0) {
+        if (city === null || lat === null || lon === null) {
             return;
         }
 
         setLoading(true);
         try {
-            const res = await fetch(route('api.v1.openweather.forecast') + `?location=${city}`);
+            const res = await fetch(route('api.v1.openweather.forecast') + `?lat=${lat}&lon=${lon}`);
             const data = await res.json();
             setData(data.data);
         } catch (error) {
@@ -33,7 +34,7 @@ export function useForecastData(city: string) {
             setData(null);
             setError(null);
         }
-    }, [city]);
+    }, [city, lat, lon]);
 
     return {
         loading,
@@ -42,16 +43,24 @@ export function useForecastData(city: string) {
     };
 }
 
-export function useWeatherData(city: string) {
+export function useWeatherData(location: { city: string; lat: number; lon: number }) {
+    const { city, lat, lon } = location;
     const [loading, setLoading] = useState<boolean>(false);
     const [data, setData] = useState<any>(null);
     const [error, setError] = useState<any>(null);
 
     const fetchData = async () => {
+        if (loading) {
+            return;
+        }
+        if (city === null || lat === null || lon === null) {
+            return;
+        }
+
         setLoading(true);
         try {
-            console.log(route('api.v1.openweather.current') + `?location=${city}`);
-            const res = await fetch(route('api.v1.openweather.current') + `?location=${city}`);
+            console.log(route('api.v1.openweather.current') + `?lat=${lat}&lon=${lon}`);
+            const res = await fetch(route('api.v1.openweather.current') + `?lat=${lat}&lon=${lon}`);
             const data = await res.json();
             setData(data.data);
         } catch (error) {
@@ -69,7 +78,7 @@ export function useWeatherData(city: string) {
             setData(null);
             setError(null);
         }
-    }, [city]);
+    }, [city, lat, lon]);
 
     return {
         loading,

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -11,7 +11,13 @@ declare global {
     /* eslint-disable no-var */
     var route: typeof ziggyRoute;
 
-    interface City { name: string; state: string | null; country: string };
+    interface City {
+        name: string;
+        state: string | null;
+        country: string;
+        lat: number;
+        lon: number;
+    };
     interface IForecastDateTime {
         dt: number;
         dt_txt: string;


### PR DESCRIPTION
# [**IMPORTANT**] This update is to prepare for the next `Onecall` integration

Since the current `weather` and `forecast` api accept both `q` and combination of `lat` and `lon` while the `onecall` api accepts `lat` and `lon` queries only, this PR is to replace all q= params in the existing current weather and forecast APIs to using `lat` and `lon`

Plus, the current cities list was actually rooted from Openweathermap, which was created based on their observation centers around the world. There are city that has multiple weather observation centers, which causes the repetitivate cities within a country, while their `lat` and `lon` are distinctive. Hence, they are still different locations.

Lastly, there are lots of cities sharing the same name but locate in different countries, states, etc. Retrieving data using `lat` and `lon` is far more reliable comparing with using city name.